### PR TITLE
Add GROK research pipeline structure

### DIFF
--- a/GROK/README.md
+++ b/GROK/README.md
@@ -1,0 +1,20 @@
+# GROK Research Pipeline
+
+This pipeline organizes the work required to research and prepare demonstrations for the most recent Groq ecosystem updates. Each stage contains guidance on where to gather information, how to validate it, and what deliverables the team should produce to be demo-ready.
+
+## Structure
+
+- `remote-mcp-on-8-models/` – Explore Groq's remote MCP support across eight available models and document how to enable each one inside our stack.
+- `mcp-tutorials-api-cookbook/` – Build seven MCP tutorials modeled after the Groq API Cookbook.
+- `compound-ga/` – Capture what changed as Compound moved from beta to general availability and produce an adoption checklist.
+- `python-sdk-v0.31.1/` – Summarize what's new in the Groq Python SDK v0.31.1 and outline upgrade testing.
+- `groq-os-templates-live/` – Track the "Build with Groq OS" template launch and provide demo runbooks.
+
+Each folder contains a `research.md` file that lists:
+
+1. Key questions to answer.
+2. Primary documentation sources to review.
+3. Validation or demo steps to run locally.
+4. Expected artifacts (notes, sample configs, recordings).
+
+Use the checklists to ensure coverage before presenting findings.

--- a/GROK/compound-ga/research.md
+++ b/GROK/compound-ga/research.md
@@ -1,0 +1,35 @@
+# Compound General Availability Launch
+
+## Objective
+Understand Compound's transition from beta to general availability (GA) within the Groq ecosystem. Produce an adoption playbook covering pricing, SLAs, and integration steps.
+
+## Key Questions
+- What feature additions or breaking changes accompanied GA?
+- What SLAs, quotas, or pricing tiers apply at GA?
+- Are there migration steps required for beta users (API endpoints, payload changes, etc.)?
+- Which customer stories or benchmarks best illustrate GA readiness?
+
+## Research Sources
+- Official Groq release notes and blog post announcing Compound GA.
+- Pricing and SLA documentation from the Groq console.
+- Recorded launch event or webinar sessions.
+- Feedback threads from beta participants.
+
+## Adoption Checklist
+1. **Gap Analysis**
+   - Compare beta vs GA API behavior and update our integration tests.
+   - Identify deprecations or new configuration toggles.
+2. **Operational Readiness**
+   - Confirm monitoring hooks (metrics, logs) for Compound endpoints.
+   - Review security requirements (data residency, compliance updates).
+3. **Enablement Materials**
+   - Draft customer-facing summary slide deck.
+   - Prepare FAQ and troubleshooting guide based on beta learnings.
+4. **Demo Script**
+   - Build a reference workflow highlighting GA-only features.
+   - Capture performance metrics before/after GA release.
+
+## Expected Artifacts
+- Migration checklist document.
+- Updated integration test plan.
+- Demo workflow configuration and supporting slides.

--- a/GROK/groq-os-templates-live/research.md
+++ b/GROK/groq-os-templates-live/research.md
@@ -1,0 +1,34 @@
+# Build with Groq OS Templates (Live)
+
+## Objective
+Capture the requirements to showcase the live "Build with Groq OS" templates. Provide instructions for deploying, customizing, and demoing the templates end-to-end.
+
+## Key Questions
+- What templates launched with the "Build with Groq OS" program and what are their target use cases?
+- How do developers access and clone the templates (GitHub, Groq console, CLI)?
+- What dependencies (SDK versions, environment variables) are required before running them?
+- How do we adapt templates to highlight MCP + n8n integrations?
+
+## Research Sources
+- Groq OS documentation hub and template repository.
+- Launch livestream or walkthrough recordings.
+- Example deployments shared by the Groq community.
+
+## Enablement Steps
+1. **Template Inventory**
+   - List each available template with description, tech stack, and prerequisites.
+   - Note licensing terms or usage restrictions.
+2. **Environment Setup**
+   - Define standard dev environment (Python/Node versions, Docker, Groq CLI).
+   - Document configuration of secrets (Groq API key, MCP endpoints).
+3. **Customization Playbook**
+   - Show how to swap the default model for a Groq-hosted option via configuration.
+   - Provide guidance for embedding templates into n8n workflows.
+4. **Demo Checklist**
+   - Create a step-by-step script for presenting the template, including data prep and success criteria.
+   - Identify telemetry to capture (latency dashboards, cost metrics).
+
+## Expected Artifacts
+- Template catalog spreadsheet.
+- Environment bootstrap scripts or `.env.example` files.
+- Demo script with presenter notes.

--- a/GROK/mcp-tutorials-api-cookbook/research.md
+++ b/GROK/mcp-tutorials-api-cookbook/research.md
@@ -1,0 +1,34 @@
+# MCP Tutorials for the Groq API Cookbook
+
+## Objective
+Design seven hands-on tutorials that showcase MCP integrations using the Groq API Cookbook patterns. Ensure each tutorial has runnable code snippets, reference data, and a demo narrative.
+
+## Key Questions
+- Which recipes in the Groq API Cookbook map cleanly to MCP use cases (chat, embeddings, structured output, tool calling, etc.)?
+- What is the minimum MCP client setup required for each tutorial?
+- How should we version tutorials as the Cookbook evolves?
+- What metrics should we capture to demonstrate Groq's latency advantage?
+
+## Research Sources
+- Groq API Cookbook GitHub repository and documentation.
+- Groq developer blog posts or webinars covering Cookbook releases.
+- Existing MCP tutorial repositories for inspiration on structure.
+
+## Tutorial Planning
+1. **Curriculum Outline**
+   - Draft seven modules covering: quickstart, streaming chat, structured JSON output, function calling, embeddings + vector search, hybrid retrieval, and evaluation/testing.
+   - For each module, define learning objectives and prerequisites.
+2. **Asset Inventory**
+   - Collect sample prompts, dataset snippets, and API payload templates from the Cookbook.
+   - Identify reusable helper scripts (authentication, logging).
+3. **Implementation Guide**
+   - Specify folder layout for tutorials (`/tutorial-N-name` with `README`, `notebook`, `demo-assets`).
+   - Outline automation to validate that code snippets stay in sync with SDK changes.
+4. **Demo Enablement**
+   - Provide presenter notes and timing cues for a 30-minute workshop.
+   - Recommend instrumentation (e.g., capturing request latency via MCP client hooks).
+
+## Expected Artifacts
+- Curriculum outline document.
+- Tutorial folders with draft READMEs and code stubs.
+- QA checklist ensuring parity between cookbook recipes and tutorials.

--- a/GROK/python-sdk-v0.31.1/research.md
+++ b/GROK/python-sdk-v0.31.1/research.md
@@ -1,0 +1,34 @@
+# Groq Python SDK v0.31.1 Upgrade Plan
+
+## Objective
+Evaluate the Groq Python SDK v0.31.1 release, catalog breaking/major changes, and define an adoption testing strategy for our services and tutorials.
+
+## Key Questions
+- What new features, bug fixes, or deprecations ship with v0.31.1?
+- Are there code changes required in existing MCP connectors or tutorials?
+- How does the new version impact dependency constraints (Python minimum version, transitive libs)?
+- What regression tests should we prioritize after upgrading?
+
+## Research Sources
+- Groq Python SDK release notes (GitHub releases, PyPI changelog).
+- Commit diff between v0.31.0 and v0.31.1 tags.
+- Internal usage analytics highlighting which SDK features we rely on most.
+
+## Upgrade Steps
+1. **Change Log Review**
+   - Summarize major entries and categorize (feature, fix, breaking).
+   - Flag items that require documentation updates.
+2. **Compatibility Audit**
+   - Run `pip install groq==0.31.1` inside a clean virtual environment.
+   - Execute our existing unit/integration test suite against the new version.
+3. **Code Updates**
+   - Patch API calls if signatures changed.
+   - Update tutorial snippets to reference new helper methods or parameters.
+4. **Release Communication**
+   - Draft internal announcement with upgrade timeline and rollback plan.
+   - Update dependency pinning guidelines in our MCP templates.
+
+## Expected Artifacts
+- Release summary memo.
+- Test run logs and coverage deltas.
+- PRs or patches applied to dependent repositories.

--- a/GROK/remote-mcp-on-8-models/research.md
+++ b/GROK/remote-mcp-on-8-models/research.md
@@ -1,0 +1,39 @@
+# Remote MCP on Eight Groq Models
+
+## Objective
+Document how to configure and demonstrate Groq's remote Model Context Protocol (MCP) gateway against eight distinct Groq-hosted models. Deliver a repeatable integration plan for our n8n MCP server.
+
+## Key Questions
+- Which Groq-hosted models currently expose MCP-compatible endpoints? (Target a representative mix of reasoning and instruction-tuned models.)
+- What authentication flow does the Groq remote MCP use (API key vs OAuth)?
+- How do we select the target model in the MCP session negotiation?
+- Are there per-model throughput or token limits that impact demos?
+- How do streaming responses behave across different models?
+
+## Research Sources
+- Groq developer changelog and model availability matrix.
+- Official MCP specification and Groq's remote MCP announcement blog post.
+- Groq API reference (especially sections covering MCP adapter configuration).
+- Community forums or Discord updates that highlight production caveats.
+
+## Setup & Demo Steps
+1. **Provision access**
+   - Request or verify Groq API credentials with MCP permissions.
+   - Enable remote MCP in the Groq dashboard if toggles exist per workspace.
+2. **Collect model identifiers**
+   - List the eight target model IDs and confirm pricing/limits.
+   - Record default context windows, supported modalities, and notable features.
+3. **Configure n8n MCP server**
+   - Update the MCP connector config to allow dynamic model selection (e.g., environment variable `GROQ_MODEL` with fallback).
+   - Generate per-model test flows that call the Groq MCP endpoint.
+4. **Run validation matrix**
+   - For each model, send a standardized prompt and capture latency, output quality, and token usage.
+   - Store results in a shared spreadsheet or Notion page to highlight differences.
+5. **Demo preparation**
+   - Create a short screen recording that shows swapping models from the MCP client UI.
+   - Prepare talking points on when to choose each model (latency vs intelligence trade-offs).
+
+## Expected Artifacts
+- Model comparison table (CSV/Sheets).
+- n8n MCP configuration snippets (JSON/YAML).
+- Demo recording and annotated slides.


### PR DESCRIPTION
## Summary
- add a GROK folder that outlines the research pipeline for recent Groq updates
- provide research guides for remote MCP coverage, cookbook tutorials, Compound GA, SDK 0.31.1, and Groq OS templates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0165b1f1c832eb17e258421714c61